### PR TITLE
added devise strong params for user can input DOB in sign up

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,10 @@
 class ApplicationController < ActionController::Base
     skip_before_action :verify_authenticity_token
+    before_action :configure_permitted_parameters, if: :devise_controller?
+
+    private
+    
+    def configure_permitted_parameters
+        devise_parameter_sanitizer.permit(:sign_up, keys: [:email, :password,:password_confirmation, :date_of_birth])
+    end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -19,4 +19,8 @@ RSpec.describe User, type: :model do
     user = User.new(email: "test@test.com", password: "123456", password_confirmation: "123456", date_of_birth: "not a date")
     expect(user).to_not be_valid
   end
+  it "is valid with a date of birth" do
+    user = User.new(email: "test@test.com", password: "123456", password_confirmation: "123456", date_of_birth: "01/01/1999")
+    expect(user).to be_valid
+  end
 end


### PR DESCRIPTION
We were unable to create a new user because of our new DOB column for devise user. We had to add strong params to allow this to happen. Conroy live coded this with us.